### PR TITLE
[dev/main branch] Main 페이지 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
+        "axios": "^1.4.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-icons": "^4.10.1",
@@ -5351,6 +5352,29 @@
       "integrity": "sha512-zIURGIS1E1Q4pcrMjp+nnEh+16G56eG/MUllJH8yEvw7asDo7Ac9uhC9KIH5jzpITueEZolfYglnCGIuSBz39g==",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.4.0.tgz",
+      "integrity": "sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==",
+      "dependencies": {
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/axobject-query": {
@@ -14330,6 +14354,11 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/psl": {
       "version": "1.9.0",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
+    "axios": "^1.4.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-icons": "^4.10.1",

--- a/src/App.js
+++ b/src/App.js
@@ -1,16 +1,47 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import "./App.css";
 import Main from "./page/Main";
 import BookmarkPage from "./page/BookmarkPage";
 import ProductListPage from "./page/ProductListPage";
+import axios from "axios";
 
 function App() {
+  const [productData, setProductData] = useState([]);
+  const [isBookmarked, setIsBookmarked] = useState(false);
+
+  useEffect(() => {
+    axios
+      .get("http://cozshopping.codestates-seb.link/api/v1/products", {
+        params: { count: 4 },
+      })
+      .then((response) => {
+        const data = response.data.map((item) => ({
+          ...item,
+          isBookmarked: false, // 북마크 상태 정보를 추가로 저장
+        }));
+        setProductData(data);
+      })
+      .catch((error) => {
+        console.error("Error", error);
+      });
+  }, []);
+
   return (
     <>
       <BrowserRouter>
         <Routes>
-          <Route path="/" element={<Main />}></Route>
+          <Route
+            path="/"
+            element={
+              <Main
+                productData={productData}
+                setProductData={setProductData}
+                isBookmarked={isBookmarked}
+                setIsBookmarked={setIsBookmarked}
+              />
+            }
+          ></Route>
           <Route path="/productlist" element={<ProductListPage />}></Route>
           <Route path="/bookmark" element={<BookmarkPage />}></Route>
         </Routes>

--- a/src/page/Main.js
+++ b/src/page/Main.js
@@ -121,15 +121,20 @@ const ProductModal = styled.div`
   }
 `;
 
-const Main = () => {
+const Main = ({
+  productData,
+  setProductData,
+  isBookmarked,
+  setIsBookmarked,
+}) => {
   // product 사진을 받아오는 상태
-  const [productData, setProductData] = useState([]);
+  // const [productData, setProductData] = useState([]); // app.js로 상태끌어올리기
   // 모달창 구현을 위한 상태
   const [showModal, setShowModal] = useState(false);
   // 클릭한 이미지의 상태 저장
   const [selectedImage, setSelectedImage] = useState(null);
   // 북마크 클릭시 상태를 저장
-  const [isBookmarked, setIsBookmarked] = useState(false);
+  // const [isBookmarked, setIsBookmarked] = useState(false); // app.js로 상태끌어올리기
 
   // product 클릭시 실행되는 핸들러 함수
   // 클릭한 이미지의 데이터를 selectedImage에 저장
@@ -138,23 +143,23 @@ const Main = () => {
     setSelectedImage(item);
   };
 
-  // product 사진을 받아오는 api, axios 사용 / 비동기처리x
-  useEffect(() => {
-    axios
-      .get("http://cozshopping.codestates-seb.link/api/v1/products", {
-        params: { count: 4 },
-      })
-      .then((response) => {
-        const data = response.data.map((item) => ({
-          ...item,
-          isBookmarked: false, // 북마크 상태 정보를 추가로 저장
-        }));
-        setProductData(data);
-      })
-      .catch((error) => {
-        console.error("Error", error);
-      });
-  }, []);
+  // product 사진을 받아오는 api, axios 사용 / 비동기처리x  => 상태끌어올리기 app.js로
+  // useEffect(() => {
+  //   axios
+  //     .get("http://cozshopping.codestates-seb.link/api/v1/products", {
+  //       params: { count: 4 },
+  //     })
+  //     .then((response) => {
+  //       const data = response.data.map((item) => ({
+  //         ...item,
+  //         isBookmarked: false, // 북마크 상태 정보를 추가로 저장
+  //       }));
+  //       setProductData(data);
+  //     })
+  //     .catch((error) => {
+  //       console.error("Error", error);
+  //     });
+  // }, []);
 
   return (
     <>
@@ -209,7 +214,22 @@ const Main = () => {
         </ItemWrapper>
         {/* 모달창 랜더링 부분 */}
         {showModal && (
-          <ProductModal onClick={() => setShowModal(false)}>
+          <ProductModal
+            isBookmarked={selectedImage.isBookmarked}
+            setIsBookmarked={(value) => {
+              const newData = productData.map((data) => {
+                if (data.id === selectedImage.id) {
+                  return {
+                    ...data,
+                    isBookmarked: value,
+                  };
+                }
+                return data;
+              });
+              setProductData(newData);
+            }}
+            onClick={() => setShowModal(false)}
+          >
             <div>
               <div className="closeButton">
                 <IoClose />
@@ -228,13 +248,13 @@ const Main = () => {
                       if (data.id === selectedImage.id) {
                         return {
                           ...data,
-                          isBookmarked: !isBookmarked, // 모달창에서 업데이트하는 항목의 북마크 상태만 업데이트
+                          isBookmarked: !selectedImage.isBookmarked,
                         };
                       }
                       return data;
                     });
                     setProductData(newData);
-                    setIsBookmarked(!isBookmarked);
+                    setIsBookmarked(!selectedImage.isBookmarked);
                   }}
                   fill={isBookmarked ? "#FFD361" : "white"}
                 />
@@ -256,7 +276,7 @@ const Main = () => {
                       if (data.id === item.id) {
                         return {
                           ...data,
-                          isBookmarked: !data.isBookmarked, // 해당 상품 항목만 업데이트
+                          isBookmarked: !isBookmarked, // 해당 상품 항목만 업데이트
                         };
                       }
                       return data;

--- a/src/page/Main.js
+++ b/src/page/Main.js
@@ -3,6 +3,8 @@ import styled from "styled-components";
 import Header from "../component/Header";
 import Footer from "../component/Footer";
 import axios from "axios";
+import { AiFillStar, IoClose } from "react-icons/io5";
+import { FaStar } from "react-icons/fa";
 
 const Container = styled.div`
   display: flex;
@@ -50,9 +52,78 @@ const ItemWrapper = styled.div`
   }
 `;
 
+const ProductModal = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
+  background: rgba(0, 0, 0, 0.8);
+  z-index: 999;
+
+  > div {
+    position: absolute;
+    left: 50%;
+    top: 50%;
+    transform: translate(-50%, -50%);
+
+    > .closeButton {
+      > svg {
+        position: absolute;
+        top: 15px;
+        right: 0;
+        width: 70px;
+        height: 45px;
+        color: white;
+        cursor: pointer;
+      }
+    }
+
+    > .bookmarkStar {
+      > svg {
+        position: absolute;
+        bottom: 30px;
+        left: 20px;
+        width: 35px;
+        height: 35px;
+        color: white;
+        cursor: pointer;
+      }
+      > div {
+        position: absolute;
+        bottom: 30px;
+        left: 65px;
+        width: 400px;
+        height: 35px;
+        color: white;
+        cursor: pointer;
+        font-size: 1.6rem;
+      }
+    }
+
+    > img {
+      width: 1100px;
+      height: 680px;
+
+      border-radius: 15px;
+    }
+  }
+`;
+
 const Main = () => {
   // product 사진을 받아오는 상태
   const [productData, setProductData] = useState([]);
+  // 모달창 구현을 위한 상태
+  const [showModal, setShowModal] = useState(false);
+  // 클릭한 이미지의 상태 저장
+  const [selectedImage, setSelectedImage] = useState(null);
+
+  // product 클릭시 실행되는 핸들러 함수
+  // 클릭한 이미지의 데이터를 selectedImage에 저장
+  const clickModal = (item) => {
+    setShowModal(!showModal);
+    setSelectedImage(item);
+  };
 
   // product 사진을 받아오는 api, axios 사용 / 비동기처리x
   useEffect(() => {
@@ -74,7 +145,11 @@ const Main = () => {
           <div className="title">상품 리스트</div>
           <div>
             {productData.map((item, idx) => (
-              <div className="itemContainer" key={idx}>
+              <div
+                className="itemContainer"
+                key={idx}
+                onClick={() => clickModal(item)}
+              >
                 <img src={item.image_url} alt={item.title} />
                 <div className="description">
                   <div>{item.title}</div>{" "}
@@ -96,7 +171,26 @@ const Main = () => {
             ))}
           </div>
         </ItemWrapper>
-
+        {/* 모달창 랜더링 부분 */}
+        {showModal && (
+          <ProductModal onClick={() => setShowModal(false)}>
+            <div>
+              <div className="closeButton">
+                <IoClose />
+              </div>
+              <img
+                src={selectedImage.image_url}
+                alt={selectedImage.title}
+                onClick={(event) => event.stopPropagation()}
+              />
+              <div className="bookmarkStar">
+                {/* 북마크 */}
+                <FaStar />
+                <div>{selectedImage.title}</div>
+              </div>
+            </div>
+          </ProductModal>
+        )}
         <ItemWrapper>
           <div className="title">북마크 리스트</div>
           <div>

--- a/src/page/Main.js
+++ b/src/page/Main.js
@@ -120,6 +120,41 @@ const ProductModal = styled.div`
   }
 `;
 
+// 이미지를 보여주는 컴포넌트 생성
+// item은 클릭은 그 상품자체의 정보를 담고있음
+// onClick은 showModal과 selectedImage 의 상태를 바꾸어주는 clickModal 핸들러 함수를 전달받음
+// handleBookmarkClick는 현재 클릭한 사진의 bookmark 이미지 클릭시 isBookmarked의 값을 바꿔주는 핸들러함수
+const ProductItem = ({ item, onClick, handleBookmarkClick }) => {
+  return (
+    <div className="itemContainer" onClick={onClick}>
+      <FaStar
+        onClick={(event) => {
+          event.stopPropagation(); // .itemContainer의 onClick 핸들러함수의 이벤트 캡쳐링을 방지하고자 썻으나, 없어도 정상작동(리팩토링 전에는 필요했음)
+          handleBookmarkClick(item);
+        }}
+        fill={item.isBookmarked ? "#FFD361" : "white"} // isBookmarked 여부에 따라 별 색상 변경
+      />
+      <img src={item.image_url} alt={item.title} />
+      <div className="description">
+        <div>{item.title}</div>
+        <div className="subDescription">
+          {item.discountPercentage !== null ? (
+            <div>{`${item.discountPercentage}%`}</div>
+          ) : item.follower ? (
+            <div>
+              관심 고객수 <br />
+              {Number(item.follower).toLocaleString()}명
+            </div>
+          ) : null}
+          {item.price !== null ? (
+            <div>{`${Number(item.price).toLocaleString()}원`}</div>
+          ) : null}
+        </div>
+      </div>
+    </div>
+  );
+};
+
 const Main = ({
   productData,
   setProductData,
@@ -160,6 +195,20 @@ const Main = ({
   //     });
   // }, []);
 
+  // 현재 클릭한 사진의 bookmark 이미지 클릭시 isBookmarked의 값을 바꿔주는 핸들러함수
+  const handleBookmarkClick = (item) => {
+    const newData = productData.map((data) => {
+      if (data.id === item.id) {
+        return {
+          ...data,
+          isBookmarked: !data.isBookmarked, // 해당 상품 항목의 isBookmarked값 업데이트
+        };
+      }
+      return data;
+    });
+    setProductData(newData); // 북마크 여부를 isBookmarked에 불린값으로 ProductData에 저장해둠 (isBookmarked 기본값 false)
+  };
+
   return (
     <>
       <Header />
@@ -168,47 +217,12 @@ const Main = ({
           <div className="title">상품 리스트</div>
           <div>
             {productData.map((item, idx) => (
-              <div
-                className="itemContainer"
+              <ProductItem
                 key={idx}
+                item={item}
                 onClick={() => clickModal(item)}
-              >
-                <FaStar
-                  onClick={(event) => {
-                    // // 이벤트 캡처링 방지, onClick={() => clickModal(item)} 실행이 될경우 원치않은 결과 초래 (모달 내부에서 bookmark 작동안함)
-                    event.stopPropagation();
-                    const newData = productData.map((data) => {
-                      if (data.id === item.id) {
-                        return {
-                          ...data,
-                          isBookmarked: !data.isBookmarked, // 해당 상품 항목만 업데이트
-                        };
-                      }
-                      return data;
-                    });
-                    setProductData(newData); // 북마크 여부를 isBookmarked에 불린값으로 ProductData에 저장해둠 (isBookmarked 기본값 false)
-                  }}
-                  fill={item.isBookmarked ? "#FFD361" : "white"} // 해당 상품 항목의 북마크 상태에 따라 색상 설정
-                />
-                <img src={item.image_url} alt={item.title} />
-                <div className="description">
-                  <div>{item.title}</div>
-
-                  <div className="subDescription">
-                    {item.discountPercentage !== null ? (
-                      <div>{`${item.discountPercentage}%`}</div>
-                    ) : item.follower ? (
-                      <div>
-                        관심 고객수 <br />
-                        {Number(item.follower).toLocaleString()}명
-                      </div>
-                    ) : null}
-                    {item.price !== null ? (
-                      <div>{`${Number(item.price).toLocaleString()}원`}</div>
-                    ) : null}
-                  </div>
-                </div>
-              </div>
+                handleBookmarkClick={handleBookmarkClick}
+              />
             ))}
           </div>
         </ItemWrapper>
@@ -226,7 +240,7 @@ const Main = ({
                 onClick={(event) => event.stopPropagation()}
               />
               <div className="bookmarkStar">
-                {/* 모달창 내부 북마크 */}
+                {/* 모달창 내부 북마크 이미지 */}
                 <FaStar
                   onClick={(event) => {
                     // 이벤트 캡처링으로 모달창 내부에서 클릭시 onClick={() => setShowModal(false)} 실행 방지
@@ -259,56 +273,19 @@ const Main = ({
           </ProductModal>
         )}
 
-        {/* 위의 상품리스트와 중복코드가 많아 추후 리팩토링예정 */}
-        {/* 위의 상품리스트와 중복코드가 많아 추후 리팩토링예정 */}
-        {/* 위의 상품리스트와 중복코드가 많아 추후 리팩토링예정 */}
+        {/*북마스 리스트 랜더링구간 */}
         <ItemWrapper>
           <div className="title">북마크 리스트</div>
           <div>
             {productData
-              .filter((item) => item.isBookmarked) //isBookmarked가 true인것만 랜더링, 추후 여러개일때 랜덤으로 받아올건지 slice(0,4)할건지 고민
+              .filter((item) => item.isBookmarked)
               .map((item, idx) => (
-                <div
-                  className="itemContainer"
+                <ProductItem
                   key={idx}
+                  item={item}
                   onClick={() => clickModal(item)}
-                >
-                  <FaStar
-                    onClick={(event) => {
-                      // // 이벤트 캡처링 방지, onClick={() => clickModal(item)} 실행이 될경우 원치않은 결과 초래 (모달 내부에서 bookmark 작동안함)
-                      event.stopPropagation();
-                      const newData = productData.map((data) => {
-                        if (data.id === item.id) {
-                          return {
-                            ...data,
-                            isBookmarked: !data.isBookmarked, // 해당 상품 항목만 업데이트
-                          };
-                        }
-                        return data;
-                      });
-                      setProductData(newData); // 북마크 여부를 isBookmarked에 불린값으로 ProductData에 저장해둠 (isBookmarked 기본값 false)
-                    }}
-                    fill={item.isBookmarked ? "#FFD361" : "white"} // 해당 상품 항목의 북마크 상태에 따라 색상 설정
-                  />
-                  <img src={item.image_url} alt={item.title} />
-                  <div className="description">
-                    <div>{item.title}</div>
-
-                    <div className="subDescription">
-                      {item.discountPercentage !== null ? (
-                        <div>{`${item.discountPercentage}%`}</div>
-                      ) : item.follower ? (
-                        <div>
-                          관심 고객수 <br />
-                          {Number(item.follower).toLocaleString()}명
-                        </div>
-                      ) : null}
-                      {item.price !== null ? (
-                        <div>{`${Number(item.price).toLocaleString()}원`}</div>
-                      ) : null}
-                    </div>
-                  </div>
-                </div>
+                  handleBookmarkClick={handleBookmarkClick}
+                />
               ))}
           </div>
         </ItemWrapper>

--- a/src/page/Main.js
+++ b/src/page/Main.js
@@ -135,54 +135,40 @@ const ProductItem = ({ item, onClick, handleBookmarkClick }) => {
         fill={item.isBookmarked ? "#FFD361" : "white"} // isBookmarked 여부에 따라 별 색상 변경
       />
       <img src={item.image_url} alt={item.title} />
-      {/* 상품 type 별 설명 분기... 리팩토링이 필요할듯 */}
-      {item.type === "Product" ? (
-        <div className="descriptionContainer">
-          <div className="subDescriptionContainer">
-            <div className="descriptionItem">{item.title}</div>
-            <div className="descriptionItem"></div>
+      <div className="descriptionContainer">
+        <div className="subDescriptionContainer">
+          <div className="descriptionItem">
+            {item.type === "Product"
+              ? item.title
+              : item.type === "Category"
+              ? `# ${item.title}`
+              : item.type === "Exhibition"
+              ? item.title
+              : item.type === "Brand"
+              ? item.brand_name
+              : ""}
           </div>
-          <div className="subDescriptionContainer2">
-            <div className="descriptionItem">{`${Number(
-              item.price
-            ).toLocaleString()}원`}</div>
-            <div className="descriptionItem">{`${item.discountPercentage}%`}</div>
-          </div>
-        </div>
-      ) : item.type === "Category" ? (
-        <div className="descriptionContainer">
-          <div className="subDescriptionContainer">
-            <div className="descriptionItem"># {item.title}</div>
-            <div className="descriptionItem"></div>
-          </div>
-          <div className="subDescriptionContainer2">
-            <div className="descriptionItem"></div>
-            <div className="descriptionItem"></div>
+          <div className="descriptionItem">
+            {item.type === "Exhibition" ? item.sub_title : ""}
           </div>
         </div>
-      ) : item.type === "Exhibition" ? (
-        <div className="descriptionContainer">
-          <div className="subDescriptionContainer">
-            <div className="descriptionItem">{item.title}</div>
-            <div className="descriptionItem">{item.sub_title}</div>
+        <div className="subDescriptionContainer2">
+          <div className="descriptionItem">
+            {item.type === "Product"
+              ? `${Number(item.price).toLocaleString()}원`
+              : item.type === "Brand"
+              ? "관심고객수"
+              : ""}
           </div>
-          <div className="subDescriptionContainer2">
-            <div className="descriptionItem"></div>
-            <div className="descriptionItem"></div>
-          </div>
-        </div>
-      ) : item.type === "Brand" ? (
-        <div className="descriptionContainer">
-          <div className="subDescriptionContainer">
-            <div className="descriptionItem">{item.brand_name}</div>
-            <div className="descriptionItem"></div>
-          </div>
-          <div className="subDescriptionContainer2">
-            <div className="descriptionItem">관심고객수</div>
-            <div className="descriptionItem">{item.follower}</div>
+          <div className="descriptionItem">
+            {item.type === "Product"
+              ? `${item.discountPercentage}%`
+              : item.type === "Brand"
+              ? item.follower
+              : ""}
           </div>
         </div>
-      ) : null}
+      </div>
     </div>
   );
 };

--- a/src/page/Main.js
+++ b/src/page/Main.js
@@ -48,12 +48,12 @@ const ItemWrapper = styled.div`
         border-radius: 15px;
         margin: 10px 65px 0px 0px;
       }
-      > .description {
+      > .descriptionContainer {
         display: flex;
         flex-direction: row;
         justify-content: space-between;
 
-        > .subDescription {
+        > .subDescriptionContainer2 {
           margin-right: 65px;
           text-align: right;
         }
@@ -135,22 +135,54 @@ const ProductItem = ({ item, onClick, handleBookmarkClick }) => {
         fill={item.isBookmarked ? "#FFD361" : "white"} // isBookmarked 여부에 따라 별 색상 변경
       />
       <img src={item.image_url} alt={item.title} />
-      <div className="description">
-        <div>{item.title}</div>
-        <div className="subDescription">
-          {item.discountPercentage !== null ? (
-            <div>{`${item.discountPercentage}%`}</div>
-          ) : item.follower ? (
-            <div>
-              관심 고객수 <br />
-              {Number(item.follower).toLocaleString()}명
-            </div>
-          ) : null}
-          {item.price !== null ? (
-            <div>{`${Number(item.price).toLocaleString()}원`}</div>
-          ) : null}
+      {/* 상품 type 별 설명 분기... 리팩토링이 필요할듯 */}
+      {item.type === "Product" ? (
+        <div className="descriptionContainer">
+          <div className="subDescriptionContainer">
+            <div className="descriptionItem">{item.title}</div>
+            <div className="descriptionItem"></div>
+          </div>
+          <div className="subDescriptionContainer2">
+            <div className="descriptionItem">{`${Number(
+              item.price
+            ).toLocaleString()}원`}</div>
+            <div className="descriptionItem">{`${item.discountPercentage}%`}</div>
+          </div>
         </div>
-      </div>
+      ) : item.type === "Category" ? (
+        <div className="descriptionContainer">
+          <div className="subDescriptionContainer">
+            <div className="descriptionItem"># {item.title}</div>
+            <div className="descriptionItem"></div>
+          </div>
+          <div className="subDescriptionContainer2">
+            <div className="descriptionItem"></div>
+            <div className="descriptionItem"></div>
+          </div>
+        </div>
+      ) : item.type === "Exhibition" ? (
+        <div className="descriptionContainer">
+          <div className="subDescriptionContainer">
+            <div className="descriptionItem">{item.title}</div>
+            <div className="descriptionItem">{item.sub_title}</div>
+          </div>
+          <div className="subDescriptionContainer2">
+            <div className="descriptionItem"></div>
+            <div className="descriptionItem"></div>
+          </div>
+        </div>
+      ) : item.type === "Brand" ? (
+        <div className="descriptionContainer">
+          <div className="subDescriptionContainer">
+            <div className="descriptionItem">{item.brand_name}</div>
+            <div className="descriptionItem"></div>
+          </div>
+          <div className="subDescriptionContainer2">
+            <div className="descriptionItem">관심고객수</div>
+            <div className="descriptionItem">{item.follower}</div>
+          </div>
+        </div>
+      ) : null}
     </div>
   );
 };

--- a/src/page/Main.js
+++ b/src/page/Main.js
@@ -142,7 +142,13 @@ const Main = () => {
       .get("http://cozshopping.codestates-seb.link/api/v1/products", {
         params: { count: 4 },
       })
-      .then((response) => setProductData(response.data))
+      .then((response) => {
+        const data = response.data.map((item) => ({
+          ...item,
+          isBookmarked: false, // 북마크 상태 정보를 추가로 저장
+        }));
+        setProductData(data);
+      })
       .catch((error) => {
         console.error("Error", error);
       });
@@ -164,9 +170,18 @@ const Main = () => {
                 <FaStar
                   onClick={(event) => {
                     event.stopPropagation();
-                    setIsBookmarked(!isBookmarked);
+                    const newData = productData.map((data) => {
+                      if (data.id === item.id) {
+                        return {
+                          ...data,
+                          isBookmarked: !data.isBookmarked, // 해당 상품 항목만 업데이트
+                        };
+                      }
+                      return data;
+                    });
+                    setProductData(newData);
                   }}
-                  fill={isBookmarked ? "#FFD361" : "white"}
+                  fill={item.isBookmarked ? "#FFD361" : "white"} // 해당 상품 항목의 북마크 상태에 따라 색상 설정
                 />
                 <img src={item.image_url} alt={item.title} />
                 <div className="description">

--- a/src/page/Main.js
+++ b/src/page/Main.js
@@ -2,41 +2,88 @@ import React, { useEffect, useState } from "react";
 import styled from "styled-components";
 import Header from "../component/Header";
 import Footer from "../component/Footer";
+import axios from "axios";
 
 const Container = styled.div`
   display: flex;
   flex-direction: column;
-  margin: 50px;
-  font-size: 2rem;
+  margin: 20px 40px 40px 65px;
+  font-size: 1.2rem;
   font-weight: 700;
+  width: auto;
 `;
 
 const ItemWrapper = styled.div`
   display: flex;
   flex-direction: column;
-  justify-content: center;
-  align-items: center;
+  width: auto;
+  margin-bottom: 40px;
+
+  .title {
+    font-size: 2rem;
+  }
+
+  > div {
+    display: flex;
+    flex-direction: row;
+    width: 100%;
+
+    .itemContainer {
+      justify-self: center;
+
+      > img {
+        width: 385px;
+        height: 280px;
+        border-radius: 15px;
+        margin: 10px 65px 10px 0px;
+      }
+    }
+  }
 `;
 
 const Main = () => {
+  // product 사진을 받아오는 상태
+  const [productData, setProductData] = useState([]);
+
+  // product 사진을 받아오는 api, axios 사용 / 비동기처리x
+  useEffect(() => {
+    axios
+      .get("http://cozshopping.codestates-seb.link/api/v1/products", {
+        params: { count: 4 },
+      })
+      .then((response) => setProductData(response.data))
+      .catch((error) => {
+        console.error("Error", error);
+      });
+  }, []);
+
   return (
     <>
       <Header />
       <Container>
-        <div>
-          상품 리스트
-          <ItemWrapper>
-            상품 사진
-            <div>사진설명</div>
-          </ItemWrapper>
-        </div>
-        <div>
-          북마크 리스트
-          <ItemWrapper>
-            북마크 사진
-            <div>사진설명</div>
-          </ItemWrapper>
-        </div>
+        <ItemWrapper>
+          <div className="title">상품 리스트</div>
+          <div>
+            {productData.map((item, idx) => (
+              <div className="itemContainer" key={idx}>
+                <img src={item.image_url} alt={item.title} />
+                <div>사진설명</div>
+              </div>
+            ))}
+          </div>
+        </ItemWrapper>
+
+        <ItemWrapper>
+          <div className="title">북마크 리스트</div>
+          <div>
+            {productData.map((item, idx) => (
+              <div className="itemContainer" key={idx}>
+                <img src={item.image_url} alt={item.title} />
+                <div>사진설명</div>
+              </div>
+            ))}
+          </div>
+        </ItemWrapper>
       </Container>
       <Footer />
     </>

--- a/src/page/Main.js
+++ b/src/page/Main.js
@@ -1,12 +1,43 @@
 import React, { useEffect, useState } from "react";
+import styled from "styled-components";
 import Header from "../component/Header";
 import Footer from "../component/Footer";
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  margin: 50px;
+  font-size: 2rem;
+  font-weight: 700;
+`;
+
+const ItemWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+`;
 
 const Main = () => {
   return (
     <>
       <Header />
-      <div>메인페이지요</div>
+      <Container>
+        <div>
+          상품 리스트
+          <ItemWrapper>
+            상품 사진
+            <div>사진설명</div>
+          </ItemWrapper>
+        </div>
+        <div>
+          북마크 리스트
+          <ItemWrapper>
+            북마크 사진
+            <div>사진설명</div>
+          </ItemWrapper>
+        </div>
+      </Container>
       <Footer />
     </>
   );

--- a/src/page/Main.js
+++ b/src/page/Main.js
@@ -17,7 +17,7 @@ const ItemWrapper = styled.div`
   display: flex;
   flex-direction: column;
   width: auto;
-  margin-bottom: 40px;
+  margin-bottom: 20px;
 
   .title {
     font-size: 2rem;
@@ -29,13 +29,22 @@ const ItemWrapper = styled.div`
     width: 100%;
 
     .itemContainer {
-      justify-self: center;
+      justify-content: center;
 
       > img {
         width: 385px;
         height: 280px;
         border-radius: 15px;
-        margin: 10px 65px 10px 0px;
+        margin: 10px 65px 0px 0px;
+      }
+      > .description {
+        display: flex;
+        flex-direction: row;
+        justify-content: space-between;
+        > .subDescription {
+          margin-right: 65px;
+          text-align: right;
+        }
       }
     }
   }
@@ -67,7 +76,22 @@ const Main = () => {
             {productData.map((item, idx) => (
               <div className="itemContainer" key={idx}>
                 <img src={item.image_url} alt={item.title} />
-                <div>사진설명</div>
+                <div className="description">
+                  <div>{item.title}</div>{" "}
+                  <div className="subDescription">
+                    {item.discountPercentage !== null ? (
+                      <div>{`${item.discountPercentage}%`}</div>
+                    ) : item.follower ? (
+                      <div>
+                        관심 고객수 <br />
+                        {Number(item.follower).toLocaleString()}명
+                      </div>
+                    ) : null}
+                    {item.price !== null ? (
+                      <div>{`${Number(item.price).toLocaleString()}원`}</div>
+                    ) : null}
+                  </div>
+                </div>
               </div>
             ))}
           </div>

--- a/src/page/Main.js
+++ b/src/page/Main.js
@@ -27,7 +27,7 @@ const ItemWrapper = styled.div`
   > div {
     display: flex;
     flex-direction: row;
-    width: 100%;
+    width: 25%;
 
     .itemContainer {
       margin-top: -40px;
@@ -258,31 +258,58 @@ const Main = ({
             </div>
           </ProductModal>
         )}
+
+        {/* 위의 상품리스트와 중복코드가 많아 추후 리팩토링예정 */}
+        {/* 위의 상품리스트와 중복코드가 많아 추후 리팩토링예정 */}
+        {/* 위의 상품리스트와 중복코드가 많아 추후 리팩토링예정 */}
         <ItemWrapper>
           <div className="title">북마크 리스트</div>
           <div>
-            {productData.map((item, idx) => (
-              <div className="itemContainer" key={idx}>
-                <FaStar
-                  onClick={(event) => {
-                    event.stopPropagation();
-                    const newData = productData.map((data) => {
-                      if (data.id === item.id) {
-                        return {
-                          ...data,
-                          isBookmarked: !isBookmarked, // 해당 상품 항목만 업데이트
-                        };
-                      }
-                      return data;
-                    });
-                    setProductData(newData);
-                  }}
-                  fill={isBookmarked ? "#FFD361" : "white"} // 해당 상품 항목의 북마크 상태에 따라 색상 설정
-                />
-                <img src={item.image_url} alt={item.title} />
-                <div>사진설명</div>
-              </div>
-            ))}
+            {productData
+              .filter((item) => item.isBookmarked) //isBookmarked가 true인것만 랜더링, 추후 여러개일때 랜덤으로 받아올건지 slice(0,4)할건지 고민
+              .map((item, idx) => (
+                <div
+                  className="itemContainer"
+                  key={idx}
+                  onClick={() => clickModal(item)}
+                >
+                  <FaStar
+                    onClick={(event) => {
+                      // // 이벤트 캡처링 방지, onClick={() => clickModal(item)} 실행이 될경우 원치않은 결과 초래 (모달 내부에서 bookmark 작동안함)
+                      event.stopPropagation();
+                      const newData = productData.map((data) => {
+                        if (data.id === item.id) {
+                          return {
+                            ...data,
+                            isBookmarked: !data.isBookmarked, // 해당 상품 항목만 업데이트
+                          };
+                        }
+                        return data;
+                      });
+                      setProductData(newData); // 북마크 여부를 isBookmarked에 불린값으로 ProductData에 저장해둠 (isBookmarked 기본값 false)
+                    }}
+                    fill={item.isBookmarked ? "#FFD361" : "white"} // 해당 상품 항목의 북마크 상태에 따라 색상 설정
+                  />
+                  <img src={item.image_url} alt={item.title} />
+                  <div className="description">
+                    <div>{item.title}</div>
+
+                    <div className="subDescription">
+                      {item.discountPercentage !== null ? (
+                        <div>{`${item.discountPercentage}%`}</div>
+                      ) : item.follower ? (
+                        <div>
+                          관심 고객수 <br />
+                          {Number(item.follower).toLocaleString()}명
+                        </div>
+                      ) : null}
+                      {item.price !== null ? (
+                        <div>{`${Number(item.price).toLocaleString()}원`}</div>
+                      ) : null}
+                    </div>
+                  </div>
+                </div>
+              ))}
           </div>
         </ItemWrapper>
       </Container>

--- a/src/page/Main.js
+++ b/src/page/Main.js
@@ -283,7 +283,7 @@ const Main = ({
                     });
                     setProductData(newData);
                   }}
-                  fill={item.isBookmarked ? "#FFD361" : "white"} // 해당 상품 항목의 북마크 상태에 따라 색상 설정
+                  fill={isBookmarked ? "#FFD361" : "white"} // 해당 상품 항목의 북마크 상태에 따라 색상 설정
                 />
                 <img src={item.image_url} alt={item.title} />
                 <div>사진설명</div>

--- a/src/page/Main.js
+++ b/src/page/Main.js
@@ -2,8 +2,7 @@ import React, { useEffect, useState } from "react";
 import styled from "styled-components";
 import Header from "../component/Header";
 import Footer from "../component/Footer";
-import axios from "axios";
-import { AiFillStar, IoClose } from "react-icons/io5";
+import { IoClose } from "react-icons/io5";
 import { FaStar } from "react-icons/fa";
 
 const Container = styled.div`
@@ -176,6 +175,7 @@ const Main = ({
               >
                 <FaStar
                   onClick={(event) => {
+                    // // 이벤트 캡처링 방지, onClick={() => clickModal(item)} 실행이 될경우 원치않은 결과 초래 (모달 내부에서 bookmark 작동안함)
                     event.stopPropagation();
                     const newData = productData.map((data) => {
                       if (data.id === item.id) {
@@ -186,7 +186,7 @@ const Main = ({
                       }
                       return data;
                     });
-                    setProductData(newData);
+                    setProductData(newData); // 북마크 여부를 isBookmarked에 불린값으로 ProductData에 저장해둠 (isBookmarked 기본값 false)
                   }}
                   fill={item.isBookmarked ? "#FFD361" : "white"} // 해당 상품 항목의 북마크 상태에 따라 색상 설정
                 />
@@ -212,24 +212,10 @@ const Main = ({
             ))}
           </div>
         </ItemWrapper>
+
         {/* 모달창 랜더링 부분 */}
-        {showModal && (
-          <ProductModal
-            isBookmarked={selectedImage.isBookmarked}
-            setIsBookmarked={(value) => {
-              const newData = productData.map((data) => {
-                if (data.id === selectedImage.id) {
-                  return {
-                    ...data,
-                    isBookmarked: value,
-                  };
-                }
-                return data;
-              });
-              setProductData(newData);
-            }}
-            onClick={() => setShowModal(false)}
-          >
+        {showModal && ( // 상품 이미지 클릭시 핸들러함수 clickModal 가 실행되어 showModal의 값이 바뀜 + 클릭한 사진이 SelectedImage 상태에 저장됨
+          <ProductModal onClick={() => setShowModal(false)}>
             <div>
               <div className="closeButton">
                 <IoClose />
@@ -240,11 +226,15 @@ const Main = ({
                 onClick={(event) => event.stopPropagation()}
               />
               <div className="bookmarkStar">
-                {/* 북마크 */}
+                {/* 모달창 내부 북마크 */}
                 <FaStar
                   onClick={(event) => {
+                    // 이벤트 캡처링으로 모달창 내부에서 클릭시 onClick={() => setShowModal(false)} 실행 방지
                     event.stopPropagation();
                     const newData = productData.map((data) => {
+                      // 모달창 내부 북마크 클릭시 => 클릭된 사진이 메인창에서 내가 클릭한 사진인지 확인
+                      // => 맞다면 isBookmarked 값을 바꾸어 줌(색상 및 isBookmarked값 변경)
+                      // => 변경된 isBookmarked 값을 productData에 업데이트
                       if (data.id === selectedImage.id) {
                         return {
                           ...data,
@@ -254,9 +244,13 @@ const Main = ({
                       return data;
                     });
                     setProductData(newData);
-                    setIsBookmarked(!selectedImage.isBookmarked);
+                    // 모달창 내부 북마크 클릭시 현재 클릭된 사진(selectedImage)의 isBookmarked값을 변경시켜줘야하기 때문에 추가한 로직
+                    setSelectedImage((prevImage) => ({
+                      ...prevImage,
+                      isBookmarked: !prevImage.isBookmarked,
+                    }));
                   }}
-                  fill={isBookmarked ? "#FFD361" : "white"}
+                  fill={selectedImage.isBookmarked ? "#FFD361" : "white"}
                 />
                 {/* 해당 상품 항목의 북마크 상태에 따라 색상 설정 */}
                 <div>{selectedImage.title}</div>

--- a/src/page/Main.js
+++ b/src/page/Main.js
@@ -31,6 +31,8 @@ const ItemWrapper = styled.div`
     width: 100%;
 
     .itemContainer {
+      margin-top: -40px;
+
       // product bookmark
       > svg {
         display: relative;
@@ -222,10 +224,21 @@ const Main = () => {
                 <FaStar
                   onClick={(event) => {
                     event.stopPropagation();
+                    const newData = productData.map((data) => {
+                      if (data.id === selectedImage.id) {
+                        return {
+                          ...data,
+                          isBookmarked: !isBookmarked, // 모달창에서 업데이트하는 항목의 북마크 상태만 업데이트
+                        };
+                      }
+                      return data;
+                    });
+                    setProductData(newData);
                     setIsBookmarked(!isBookmarked);
                   }}
                   fill={isBookmarked ? "#FFD361" : "white"}
                 />
+                {/* 해당 상품 항목의 북마크 상태에 따라 색상 설정 */}
                 <div>{selectedImage.title}</div>
               </div>
             </div>
@@ -236,6 +249,22 @@ const Main = () => {
           <div>
             {productData.map((item, idx) => (
               <div className="itemContainer" key={idx}>
+                <FaStar
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    const newData = productData.map((data) => {
+                      if (data.id === item.id) {
+                        return {
+                          ...data,
+                          isBookmarked: !data.isBookmarked, // 해당 상품 항목만 업데이트
+                        };
+                      }
+                      return data;
+                    });
+                    setProductData(newData);
+                  }}
+                  fill={item.isBookmarked ? "#FFD361" : "white"} // 해당 상품 항목의 북마크 상태에 따라 색상 설정
+                />
                 <img src={item.image_url} alt={item.title} />
                 <div>사진설명</div>
               </div>

--- a/src/page/Main.js
+++ b/src/page/Main.js
@@ -31,7 +31,15 @@ const ItemWrapper = styled.div`
     width: 100%;
 
     .itemContainer {
-      justify-content: center;
+      // product bookmark
+      > svg {
+        display: relative;
+        transform: translate(330px, 275px);
+        width: 35px;
+        height: 35px;
+        color: white;
+        cursor: pointer;
+      }
 
       > img {
         width: 385px;
@@ -43,6 +51,7 @@ const ItemWrapper = styled.div`
         display: flex;
         flex-direction: row;
         justify-content: space-between;
+
         > .subDescription {
           margin-right: 65px;
           text-align: right;
@@ -117,6 +126,8 @@ const Main = () => {
   const [showModal, setShowModal] = useState(false);
   // 클릭한 이미지의 상태 저장
   const [selectedImage, setSelectedImage] = useState(null);
+  // 북마크 클릭시 상태를 저장
+  const [isBookmarked, setIsBookmarked] = useState(false);
 
   // product 클릭시 실행되는 핸들러 함수
   // 클릭한 이미지의 데이터를 selectedImage에 저장
@@ -150,9 +161,17 @@ const Main = () => {
                 key={idx}
                 onClick={() => clickModal(item)}
               >
+                <FaStar
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    setIsBookmarked(!isBookmarked);
+                  }}
+                  fill={isBookmarked ? "#FFD361" : "white"}
+                />
                 <img src={item.image_url} alt={item.title} />
                 <div className="description">
-                  <div>{item.title}</div>{" "}
+                  <div>{item.title}</div>
+
                   <div className="subDescription">
                     {item.discountPercentage !== null ? (
                       <div>{`${item.discountPercentage}%`}</div>
@@ -185,7 +204,13 @@ const Main = () => {
               />
               <div className="bookmarkStar">
                 {/* 북마크 */}
-                <FaStar />
+                <FaStar
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    setIsBookmarked(!isBookmarked);
+                  }}
+                  fill={isBookmarked ? "#FFD361" : "white"}
+                />
                 <div>{selectedImage.title}</div>
               </div>
             </div>

--- a/src/page/ProductListPage.js
+++ b/src/page/ProductListPage.js
@@ -1,8 +1,26 @@
 import React, { useEffect, useState } from "react";
 import Header from "../component/Header";
 import Footer from "../component/Footer";
+import axios from "axios";
 
-const ProductListPage = () => {
+const ProductListPage = ({ setProductData }, { isBookmarked }) => {
+  // product 사진을 받아오는 api, axios 사용 / 비동기처리x
+  useEffect(() => {
+    axios
+      .get("http://cozshopping.codestates-seb.link/api/v1/products", {
+        params: { count: 4 },
+      })
+      .then((response) => {
+        const data = response.data.map((item) => ({
+          ...item,
+          isBookmarked: false, // 북마크 상태 정보를 추가로 저장
+        }));
+        setProductData(data);
+      })
+      .catch((error) => {
+        console.error("Error", error);
+      });
+  }, []);
   return (
     <>
       <Header />


### PR DESCRIPTION
 # [dev/main branch] Main 페이지 구현 내용 :memo: 


# Main Page
- [x] 모든 타입의 상품 정보를 4개 보여주기 (필터기능 없이)
- [x] 모든 타입의 북마크 된 상품 정보를 4개 보여주기 (필터기능 없이) 
- [x]    => 보여지는 상품의 타입은 혼합되어 있음(상품, 카테고리, 기획전, 브랜드)
- [x] 상품 클릭시 모달창 구현
- [x] 모달창내/외부에서 BookMark 이미지 클릭 시 BookMark 상태 변경

## 공통
- [x]  path: `/`


##  Header 컴포넌트
- [x] Header와 Footer를 갖고 있으며, 해당 GNB와 Footer는 어느 페이지를 가더라도 항상 존재
- [x] Header는 페이지 내 스크롤이 발생하더라도 항상 상단에 붙어있어야함



## 햄버거 버튼
- [x] 메인로고 → 클릭하면  `/` 페이지로 이동
- [x] 상품리스트 → 클릭하면 `/products/list` 페이지로 이동
- [x] 북마크페이지 → 클릭하면 `/bookmark` 페이지로 이동



## Footer 컴포넌트
- [x] 일련의 텍스트 정보 기입


## 🩹 Issue 🩹
- [ ] Header, Footer 컴포넌트 App.js에서 랜더링하도록 수정 필요
- [x] 현재 Main페이지에서 선언해 놓은 ProductItem, ProductItem 컴포넌트를 별도의 파일로 관리하기 위해 리팩토링 할 예정임 (ProductList페이지, Bookmark페이지에서 재사용하기 때문)
![image](https://github.com/WONHO22/fe-sprint-coz-shopping/assets/129931980/9856af34-e42e-41d4-af62-163b15a2f6f3)







